### PR TITLE
Expand NVS version string regex to support arm

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -2,7 +2,7 @@
 const path = require('path');
 
 const versionRegex =
-    /^(([\w\-]+)\/)?((v?(\d+(\.\d+(\.\d+)?)?(-[0-9A-Za-z.]+)?))|([a-z][a-z_\-][0-9a-z_\-]*))(\/((x86)|(32)|((x)?64)))?$/i;
+    /^(([\w\-]+)\/)?((v?(\d+(\.\d+(\.\d+)?)?(-[0-9A-Za-z.]+)?))|([a-z][a-z_\-][0-9a-z_\-]*))(\/((x86)|(arm)|(32)|((x)?64)))?$/i;
 
 class NodeVersion {
     constructor(remoteName, semanticVersion, arch) {


### PR DESCRIPTION
At least on Windows, this allows nvs to look for windows arm builds. On Linux, I see usage of arm64, armv6l and armv7l, so there might be some straightening out we need to do here longer term, in terms of which platforms support which architectures.