### PR TITLE
add fuzzy matching for versions

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -5,6 +5,7 @@ const path = require('path');
 
 const versionRegex =
 	/^(([\w-]+)\/)?((v?(\d+(\.\d+(\.\d+)?)?(-[0-9A-Za-z.-]+)?))|([a-z][a-z_-][0-9a-z_-]*))(\/((x86)|(32)|((x)?64)|(arm\w*)|(ppc\w*)))?$/i;
+const specialLabels = /^(lts|latest|default|current)$/;
 
 class NodeVersion {
 	constructor(remoteName, semanticVersion, arch) {
@@ -62,6 +63,14 @@ class NodeVersion {
 		let semanticVersion = match[5] || null;
 		let label = match[9];
 		let arch = match[11];
+
+		// if the input is just a simple string, treat it as a fuzzy match query
+		if (!specialLabels.test(label) &&
+			 match[0] === match[3] &&
+			 match[0] === match[9] &&
+			 match[0] === match.input) {
+			return new FuzzyNodeVersion(versionString);
+		}
 
 		if (requireFull) {
 			if (!remoteName) {
@@ -138,6 +147,10 @@ class NodeVersion {
 	 * Tests if two node version structures are equal.
 	 */
 	static equal(versionA, versionB) {
+		// fuzzy-only versions are never "equal" to anything.
+		if (versionA.fuzzy || versionB.fuzzy) {
+			return false;
+		}
 		return versionA.remoteName === versionB.remoteName &&
             versionA.semanticVersion === versionB.semanticVersion &&
             versionA.arch === versionB.arch &&
@@ -259,6 +272,18 @@ class NodeVersion {
 			(this.arch ? '/' + this.arch : '') +
 			(options && options.label && (this.semanticVersion || this.path) && this.label
 				? ' (' + this.label + ')' : '');
+	}
+}
+
+class FuzzyNodeVersion extends NodeVersion {
+	constructor(fuzzy) {
+		super(); //null, null, null);
+		this.fuzzy = fuzzy;
+	}
+	match(specificVersion) {
+		let res = specificVersion.toString().includes(this.fuzzy);
+		// console.log('fuzzy match: %s =~ %s == %j', this.fuzzy, specificVersion, res);
+		return res;
 	}
 }
 

--- a/test/modules/versionTests.js
+++ b/test/modules/versionTests.js
@@ -8,6 +8,7 @@ global.settings = {
 		'default': 'test',
 		'test': 'http://example.com/test',
 		'test2': 'http://example.com/test2',
+		'chakracore-nightly': 'https://nodejs.org/download/chakracore-nightly/',
 	},
 };
 
@@ -155,6 +156,38 @@ test('GetBinaryNameFromVersion', t => {
 	t.is(NodeVersion.getBinaryNameFromVersion('5.6'), 'node');
 	t.is(NodeVersion.getBinaryNameFromVersion('6.8'), 'node');
 	t.is(NodeVersion.getBinaryNameFromVersion('7.8'), 'node');
+});
+
+test('FuzzyNodeVersion', t => {
+	const vA = new NodeVersion('test', '5.6.7', 'x64');
+	const vB = new NodeVersion('chakracore-nightly', '8.0.0-nightly123455', 'x64');
+	const vBr = new NodeVersion('chakracore-nightly', '8.0.0', 'x64');
+	const vC = new NodeVersion('node', '5.5.6', 'x64');
+
+	const fvA = NodeVersion.parse('node');
+	t.truthy(fvA.fuzzy);
+	t.falsy(fvA.match(vA));
+	t.falsy(fvA.match(vB));
+	t.truthy(fvA.match(vC));
+
+	const fvB = NodeVersion.parse('chakra');
+	t.truthy(fvB.fuzzy);
+	t.falsy(fvB.match(vA));
+	t.truthy(fvB.match(vB));
+	t.falsy(fvB.match(vC));
+
+	const fvC = NodeVersion.parse('5');
+	t.falsy(fvC.fuzzy);
+	t.truthy(fvC.match(vA));
+	t.falsy(fvC.match(vB));
+	t.falsy(fvC.match(vC));
+
+	const fvD = NodeVersion.parse('8');
+	t.falsy(fvD.fuzzy);
+	t.falsy(fvD.match(vA));
+	t.falsy(fvD.match(vB));
+	t.falsy(fvD.match(vBr));
+	t.falsy(fvD.match(vC));
 });
 
 test.todo('Match');


### PR DESCRIPTION
Extend the existing NodeVersion class with a FuzzyNodeVersion class that
overrides the .match() method behaviour to do a fuzzy match against the
given version.

A FuzzyNodeVersion is created when a given "version" input string is
just a simple string that doesn't map to an existing special case (lts,
current, default, latest) and isn't simply a number (does semver
matchign against default remote).

Closes #37

This does _not_ include any sort of documentation since I wanted to get the concept and implementation sorted out first.