### PR TITLE
allow main menu to be suppressed by settings.json

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -71,7 +71,8 @@ function doCommand(args) {
 	let version = null;
 	switch (args[0]) {
 		case undefined:
-			return require('./mainMenu').showMainMenuAsync();
+			if (settings.hideMenu) return require('./help')();
+			else return require('./mainMenu').showMainMenuAsync();
 
 		case 'install':
 			if (args[1]) return help('install');


### PR DESCRIPTION
Check for `hideMenu` to suppress showing the interactive main menu when
no command is specified.

Resolves #38

@jasongin I would have preferred to use `showMenu` but that would have required uglier code to differentiate between `false` meaning to hide the menu and `undefined`/`true` meaning to follow the current behaviour of showing the menu.