### PR TITLE
Add support for iojs

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -4,6 +4,7 @@
 	"remotes": {
 	"default": "node",
 		"node": "https://nodejs.org/dist/",
+		"iojs": "https://iojs.org/dist/",
 		"nightly": "https://nodejs.org/download/nightly/",
 		"chakracore": "https://github.com/nodejs/node-chakracore/releases/",
 		"chakracore-nightly": "https://nodejs.org/download/chakracore-nightly/"

--- a/lib/addRemove.js
+++ b/lib/addRemove.js
@@ -64,7 +64,7 @@ function addAsync(version, useNow) {
 			let versionDir = nvsUse.getVersionDir(version);
 			removeDirectoryRecursive(versionDir);
 
-			let remoteUri = settings.remotes[version.remoteName];
+			let remoteUri = version.uri;
 			return downloadAndExtractAsync(version, remoteUri).then(() => {
 				if (label) {
 					fs.writeFileSync(path.join(nvsUse.getVersionDir(version), '.nvs'),

--- a/lib/addRemove.js
+++ b/lib/addRemove.js
@@ -64,8 +64,7 @@ function addAsync(version, useNow) {
 			let versionDir = nvsUse.getVersionDir(version);
 			removeDirectoryRecursive(versionDir);
 
-			let remoteUri = version.uri;
-			return downloadAndExtractAsync(version, remoteUri).then(() => {
+			return downloadAndExtractAsync(version).then(() => {
 				if (label) {
 					fs.writeFileSync(path.join(nvsUse.getVersionDir(version), '.nvs'),
 						JSON.stringify({ label }, null, '\t'));
@@ -90,7 +89,7 @@ function addAsync(version, useNow) {
 /**
  * Downloads and extracts a version of node.
  */
-function downloadAndExtractAsync(version, remoteUri) {
+function downloadAndExtractAsync(version) {
 	let archiveFileName = version.remoteName + '-v' + version.semanticVersion +
 		'-' + version.os + '-' + version.arch + version.ext;
 

--- a/lib/list.js
+++ b/lib/list.js
@@ -347,6 +347,9 @@ function nodeReleaseInfoToVersion(remoteName, remoteUri, release) {
 			// The MSI is not actually installed, though it is assumed that the contained
 			// files are laid out in a consistent way.
 			if (settings.useMsi ||
+					// iojs versions
+					NodeVersion.getBinaryNameFromVersion(semanticVersion) === 'iojs' ||
+					// nodejs versions
 					/^0\./.test(semanticVersion) ||
 					/^4\.[0-4]\./.test(semanticVersion) ||
 					/^5\./.test(semanticVersion) ||
@@ -374,19 +377,20 @@ function nodeReleaseInfoToVersion(remoteName, remoteUri, release) {
 		}
 
 		let uri;
+		let binaryName = NodeVersion.getBinaryNameFromVersion(semanticVersion);
 		if (ext === '.msi') {
 			uri = remoteUri + (remoteUri.endsWith('/') ? '' : '/') +
-				'v' + semanticVersion + '/' + 'node-v' + semanticVersion +
+				'v' + semanticVersion + '/' + binaryName + '-v' + semanticVersion +
 				'-' + arch + ext;
 			if (/^0\./.test(semanticVersion) && arch === 'x64') {
 				// In 0.x versions, the x64 MSI is under an x64 subdirectory.
 				uri = uri.substr(0, uri.lastIndexOf('/') + 1) +
-					arch + '/' + 'node-v' + semanticVersion +
+					arch + '/' + binaryName + '-v' + semanticVersion +
 					'-' + arch + ext;
 			}
 		} else {
 			uri = remoteUri + (remoteUri.endsWith('/') ? '' : '/') +
-				'v' + semanticVersion + '/' + 'node-v' + semanticVersion +
+				'v' + semanticVersion + '/' + binaryName + '-v' + semanticVersion +
 				'-' + os + '-' + arch + ext;
 		}
 

--- a/lib/use.js
+++ b/lib/use.js
@@ -361,7 +361,8 @@ function getVersionBinary(version) {
 	}
 
 	// Resolve the version to a path and check if the binary exists.
-	let nodeBinPath = path.join(getVersionBinDir(version), isWindows ? 'node.exe' : 'node');
+	let binaryName = NodeVersion.getBinaryNameFromVersion(version.semanticVersion);
+	let nodeBinPath = path.join(getVersionBinDir(version), isWindows ? binaryName + '.exe' : binaryName);
 	try {
 		fs.accessSync(nodeBinPath, fs.constants.X_OK);
 		return nodeBinPath;

--- a/lib/version.js
+++ b/lib/version.js
@@ -216,20 +216,20 @@ class NodeVersion {
 
 		return semver;
 	}
-	
+
 	/**
 	* Get the binary name to be used based on version passed.
 	* 'node' for version 0.X or 4.X and above
 	* 'iojs' for version 1.X, 2.X and 3.X
 	*/
 	static getBinaryNameFromVersion(semanticVersion) {
-			if(/^1\./.test(semanticVersion) ||
-				 /^2\./.test(semanticVersion) ||
-				 /^3\./.test(semanticVersion)) {
-					 return 'iojs';
-			} else {
-					 return 'node';
-			}
+		if (/^1\./.test(semanticVersion) ||
+				/^2\./.test(semanticVersion) ||
+				/^3\./.test(semanticVersion)) {
+			return 'iojs';
+		} else {
+			return 'node';
+		}
 	}
 
 	/**

--- a/lib/version.js
+++ b/lib/version.js
@@ -216,6 +216,21 @@ class NodeVersion {
 
 		return semver;
 	}
+	
+	/**
+	* Get the binary name to be used based on version passed.
+	* 'node' for version 0.X or 4.X and above
+	* 'iojs' for version 1.X, 2.X and 3.X
+	*/
+	static getBinaryNameFromVersion(semanticVersion) {
+			if(/^1\./.test(semanticVersion) ||
+				 /^2\./.test(semanticVersion) ||
+				 /^3\./.test(semanticVersion)) {
+					 return 'iojs';
+			} else {
+						return 'node';
+			}
+	}
 
 	/**
 	 * Tests if a partial version (filter) matches a specific version.

--- a/lib/version.js
+++ b/lib/version.js
@@ -228,7 +228,7 @@ class NodeVersion {
 				 /^3\./.test(semanticVersion)) {
 					 return 'iojs';
 			} else {
-						return 'node';
+					 return 'node';
 			}
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nvs",
-	"version": "1.2.1",
+	"version": "1.3.0",
 	"description": "Node Version Switcher",
 	"main": "lib/main.js",
 	"scripts": {

--- a/test/modules/versionTests.js
+++ b/test/modules/versionTests.js
@@ -130,4 +130,15 @@ test('Compare', t => {
 	t.deepEqual(sorted, [vA, vB, vC, vD, vE, vF, vG, vH, vI, vJ, vK]);
 });
 
+test('GetBinaryNameFromVersion', t => {
+	t.is(NodeVersion.getBinaryNameFromVersion('0.12'), 'node');
+	t.is(NodeVersion.getBinaryNameFromVersion('1.8'), 'iojs');
+	t.is(NodeVersion.getBinaryNameFromVersion('2.0'), 'iojs');
+	t.is(NodeVersion.getBinaryNameFromVersion('3.2'), 'iojs');
+	t.is(NodeVersion.getBinaryNameFromVersion('4.3'), 'node');
+	t.is(NodeVersion.getBinaryNameFromVersion('5.6'), 'node');
+	t.is(NodeVersion.getBinaryNameFromVersion('6.8'), 'node');
+	t.is(NodeVersion.getBinaryNameFromVersion('7.8'), 'node');
+});
+
 test.todo('Match');


### PR DESCRIPTION
* Added support for iojs binaries available at https://iojs.org/dist/
* Added `iojs` as one of the default remotes
* Added a test-case for new `NodeVersion.getBinaryNameFromVersion()`

Let me know if you want to add more test cases around iojs.