### PR TITLE
Support for older node versions

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -317,7 +317,9 @@ function getNodejsRemoteVersionsAsync(remoteName, remoteUri) {
  */
 function nodeReleaseInfoToVersion(remoteName, remoteUri, release) {
 	let semanticVersion = release.version;
-	if (!semanticVersion.startsWith('v')) {
+	if (!semanticVersion.startsWith('v') ||
+			(semanticVersion.startsWith('v0') && !/^v0.[7-9]|1[0-9]/.test(semanticVersion))) {
+			// Filter out very old versions (< v0.7) that are not supported by NVS.
 		return null;
 	}
 

--- a/lib/list.js
+++ b/lib/list.js
@@ -317,9 +317,7 @@ function getNodejsRemoteVersionsAsync(remoteName, remoteUri) {
  */
 function nodeReleaseInfoToVersion(remoteName, remoteUri, release) {
 	let semanticVersion = release.version;
-	if (!semanticVersion.startsWith('v') ||
-        (semanticVersion.startsWith('v0') && !/^v0.1[0-9]/.test(semanticVersion))) {
-		// Filter out very old versions (< v0.10) that are not supported by NVS.
+	if (!semanticVersion.startsWith('v')) {
 		return null;
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nvs",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "Node Version Switcher",
 	"main": "lib/main.js",
 	"scripts": {


### PR DESCRIPTION
Removed condition that was prohibiting NVS using for node versions older than `0.10`. Bumped the version to `1.3.1`.