### PR TITLE
Allow custom GitHub API proxies

### DIFF
--- a/doc/CI.md
+++ b/doc/CI.md
@@ -93,3 +93,12 @@ To resolve the issue:
  **Do not put the token directly into a `.yml` configuration file.**
 
 NVS automatically uses the value from the `NVS_GITHUB_TOKEN` environment variable to authenticate GitHub API requests.
+
+## GitHub API Proxy
+Some hosted CI solutions like Travis CI and AppVeyor do not allow encrypted variables to be read from forks. In this case an encrypted `NVS_GITHUB_TOKEN` will not be available when building a pull request which can lead to instability in CI. An alternative approach is to host a GitHub API proxy which injects a Personal Access Token into the `Authorization` header.
+
+To configure NVS to use a GitHub API proxy
+ 1. In the CI job settings web page, define an environment variable named `NVS_GITHUB_API_HOSTNAME` and paste in your proxy hostname without the scheme i.e. `api.my-proxy.com`.
+ **The proxy must be https enabled.**
+
+NVS automatically uses the value from the `NVS_GITHUB_API_HOSTNAME` environment variable when making GitHub API requests.

--- a/lib/list.js
+++ b/lib/list.js
@@ -440,8 +440,9 @@ function getGithubRemoteVersionsAsync(remoteName, remoteUri) {
 			headers['Authorization'] = 'token ' + token;
 		}
 
+		let hostname = process.env['NVS_GITHUB_API_HOSTNAME'] || 'api.github.com';
 		https.get({
-			hostname: 'api.github.com',
+			hostname: hostname,
 			path: `/repos/${owner}/${repo}/releases`,
 			headers,
 		}, (res) => {

--- a/test/modules/listTests.js
+++ b/test/modules/listTests.js
@@ -483,6 +483,21 @@ test('Get remote versions - github releases index not found', t => {
 	});
 });
 
+test('Get remote versions - custom github releases index not found', t => {
+	process.env['NVS_GITHUB_API_HOSTNAME'] = 'api.not-github.com';
+	delete mockHttp.resourceMap['https://api.not-github.com/repos/nodejs/node/releases'];
+	const testReleasesUri = 'https://github.com/nodejs/node/releases/';
+	return getGithubRemoteVersionsAsync('test1', testReleasesUri).then(result => {
+		t.fail();
+		delete process.env['NVS_GITHUB_API_HOSTNAME'];
+	}).catch(e => {
+		t.truthy(e);
+		t.truthy(e.cause);
+		t.true(e.cause.message.indexOf('404') >= 0);
+		delete process.env['NVS_GITHUB_API_HOSTNAME'];
+	});
+});
+
 test('Get remote versions - network path', t => {
 	const testNetworkPath = '\\\\server\\share\\path\\';
 	mockFs.mockDir(testNetworkPath, ['5.6.7','7.8.9']);


### PR DESCRIPTION
It's not always possible to use `NVS_GITHUB_TOKEN` in CI builds.
Most popular freely hosted CI environments don't allow encrypted
tokens to be used for [forked builds][1]. This can lead to instable
PR builds. To get around this restriction it's common to use an API
proxy with the an auth token baked in.

This PR enables users to provide a proxy GitHub API proxy hostname
via the `NVS_GITHUB_API_HOSTNAME` environment variable.

[1]: https://docs.travis-ci.com/user/environment-variables/#Defining-encrypted-variables-in-.travis.yml