### PR TITLE
Update Chakracore default remote

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -6,7 +6,7 @@
 		"node": "https://nodejs.org/dist/",
 		"iojs": "https://iojs.org/dist/",
 		"nightly": "https://nodejs.org/download/nightly/",
-		"chakracore": "https://github.com/nodejs/node-chakracore/releases/",
+		"chakracore": "https://nodejs.org/download/chakracore-release/",
 		"chakracore-nightly": "https://nodejs.org/download/chakracore-nightly/"
 	},
 	"bootstrap": "node/6.10.1"


### PR DESCRIPTION
Now that nodejs.org started hosting chakracore-release, change the default remote
for `chakracore` to https://nodejs.org/download/chakracore-release/.

This will help using nvs for https://github.com/expressjs/express/pull/3251 , https://github.com/expressjs/body-parser/pull/233
and https://github.com/sass/node-sass/pull/1777