### PR TITLE
Support downloading .gz on non-windows for older version of node

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -360,13 +360,13 @@ function nodeReleaseInfoToVersion(remoteName, remoteUri, release) {
 				ext = '.7z';
 			}
 		} else {
-            // Official builds before 0.12.10, 0.10.42 or 0.8.6 did not publish .tar.xz packages.
+            // Official builds before 0.12.10, 0.10.42 or 0.8.* did not publish .tar.xz packages.
 			if (process.env['NVS_USE_XZ'] === '1' && !(
 					/^0\.12\.[0-9]$/.test(semanticVersion) ||
 					/^0\.11\./.test(semanticVersion) ||
 					/^0\.10\.4[0-1]$/.test(semanticVersion) ||
 					/^0\.10\.[1-3]?[0-9]$/.test(semanticVersion) ||
-					/^0\.8\.([6-9]|[1-2][0-9])$/.test(semanticVersion))) {
+					/^0\.8\./.test(semanticVersion))) {
 				ext = '.tar.xz';
 			} else {
 				ext = '.tar.gz';

--- a/lib/list.js
+++ b/lib/list.js
@@ -360,12 +360,13 @@ function nodeReleaseInfoToVersion(remoteName, remoteUri, release) {
 				ext = '.7z';
 			}
 		} else {
-            // Official builds before 0.12.10 or 0.10.42 did not publish .tar.xz packages.
+            // Official builds before 0.12.10, 0.10.42 or 0.8.6 did not publish .tar.xz packages.
 			if (process.env['NVS_USE_XZ'] === '1' && !(
 					/^0\.12\.[0-9]$/.test(semanticVersion) ||
 					/^0\.11\./.test(semanticVersion) ||
 					/^0\.10\.4[0-1]$/.test(semanticVersion) ||
-					/^0\.10\.[1-3]?[0-9]$/.test(semanticVersion))) {
+					/^0\.10\.[1-3]?[0-9]$/.test(semanticVersion) ||
+					/^0\.8\.([6-9]|[1-2][0-9])$/.test(semanticVersion))) {
 				ext = '.tar.xz';
 			} else {
 				ext = '.tar.gz';


### PR DESCRIPTION
Allow `.gz` files to be downloadable for node version `0.8.5` and above on non-windows platform.