### PR TITLE
fix: allow endian detection for ppc64

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const path = require('path');
+const os = require('os');
 
 const versionRegex =
 	/^(([\w-]+)\/)?((v?(\d+(\.\d+(\.\d+)?)?(-[0-9A-Za-z.-]+)?))|([a-z][a-z_-][0-9a-z_-]*))(\/((x86)|(32)|((x)?64)|(arm\w*)|(ppc\w*)))?$/i;
@@ -114,6 +115,8 @@ class NodeVersion {
 			case 'x64':
 			case 'amd64':
 				return 'x64';
+			case 'ppc64':
+			return (os.endianness() == 'LE' ? 'ppc64le' : 'ppc64');
 			case 'arm':
 				return process.config.variables.arm_version
 					? 'armv' + process.config.variables.arm_version + 'l' : 'arm';

--- a/test/modules/versionTests.js
+++ b/test/modules/versionTests.js
@@ -114,6 +114,7 @@ test('Parse remote, version label and arch', t => {
 });
 
 test('Parse other architectures', t => {
+	const os = require('os');
 	let v = NodeVersion.parse('test/latest/x64');
 	t.is(v.arch, 'x64');
 	v = NodeVersion.parse('test/latest/32');
@@ -125,7 +126,11 @@ test('Parse other architectures', t => {
 	v = NodeVersion.parse('test/latest/arm64');
 	t.is(v.arch, 'arm64');
 	v = NodeVersion.parse('test/latest/ppc64');
-	t.is(v.arch, 'ppc64');
+	if (os.endianness() == 'LE') {
+		t.is(v.arch, 'ppc64le');
+	} else {
+		t.is(v.arch, 'ppc64');
+	}
 });
 
 test('Compare', t => {


### PR DESCRIPTION
fixes: https://github.com/jasongin/nvs/issues/97

This change allows users on ppc64le (little endian) to also use NVS as by default it offers them ppc64 which is not available for Node8.