### PR TITLE
Fix random postscript name clash

### DIFF
--- a/nvs.ps1
+++ b/nvs.ps1
@@ -11,7 +11,7 @@ if (-not $env:NVS_HOME) {
 
 if (-not ($args -eq "bootstrap")) {
 	# Generate 31 bits of randomness, to avoid clashing with concurrent executions.
-	$env:NVS_POSTSCRIPT = Join-Path $env:NVS_HOME ("nvs_tmp_" + (Get-Random) + ".ps1")
+	$env:NVS_POSTSCRIPT = Join-Path $env:NVS_HOME ("nvs_tmp_" + (Get-Random -SetSeed $PID) + ".ps1")
 }
 
 # Check if the bootstrap node.exe is present.


### PR DESCRIPTION
The PowerShell script uses `Get-Random` to avoid clashes when generating the temporary post script file, however this can still collide occasionally (it seems different processes may be seeding the random number generator based on the current time).

This change uses the process ID as the seed, so that the seeds between concurrently opened shells won't collide.

In my setup, I open three shells every time I start up my terminal, and I occasionally (maybe a few times a month) see an error like this:
>ENOENT: no such file or directory, lstat 'C:\Users\bdukes\AppData\Local\nvs\nvs_tmp_1855413075.ps1'