### PR TITLE
Fix quote wrapping omission

### DIFF
--- a/nvs.sh
+++ b/nvs.sh
@@ -96,6 +96,7 @@ nvs() {
 	fi
 
 	local EXIT_CODE
+	EXIT_CODE=0
 
 	# Check if invoked as a CD function that enables auto-switching.
 	case "$@" in
@@ -125,7 +126,7 @@ nvs() {
 			;;
 	esac
 
-	if [ "${EXIT_CODE}" = "2" ]; then
+	if [ ${EXIT_CODE} = 2 ]; then
 		# The bootstrap node version is wrong. Delete it and start over.
 		rm "${NODE_PATH}"
 		nvs $@

--- a/nvs.sh
+++ b/nvs.sh
@@ -125,7 +125,7 @@ nvs() {
 			;;
 	esac
 
-	if [ ${EXIT_CODE} = 2 ]; then
+	if [ "${EXIT_CODE}" = "2" ]; then
 		# The bootstrap node version is wrong. Delete it and start over.
 		rm "${NODE_PATH}"
 		nvs $@

--- a/nvs.sh
+++ b/nvs.sh
@@ -95,8 +95,7 @@ nvs() {
 		echo ""
 	fi
 
-	local EXIT_CODE
-	EXIT_CODE=0
+	local EXIT_CODE=0
 
 	# Check if invoked as a CD function that enables auto-switching.
 	case "$@" in


### PR DESCRIPTION
This seems to be the cause of this error I was getting when I set up nvs auto-switching on a new laptop:

```
bash: [: =: unary operator expected
```

Not a bash expert, but I'm guessing `${EXIT_CODE}` without quotes evaluated to empty, but the `=` operator expected arguments on both sides?