### PR TITLE
nvs auto on: Fix zsh alias function

### DIFF
--- a/lib/auto.js
+++ b/lib/auto.js
@@ -112,9 +112,9 @@ function enableAutoSwitch(enable) {
 				'} > $null',
 			],
 			'.SH': [
-				'cd () { builtin cd "$@" && nvs cd; }',
-				'pushd () { builtin pushd "$@" && nvs cd; }',
-				'popd () { builtin popd "$@" && nvs cd; }',
+				'function cd () { builtin cd "$@" && nvs cd; }',
+				'function pushd () { builtin pushd "$@" && nvs cd; }',
+				'function popd () { builtin popd "$@" && nvs cd; }',
 			],
 		});
 	} else {
@@ -128,9 +128,9 @@ function enableAutoSwitch(enable) {
 				'}',
 			],
 			'.SH': [
-				'cd () { builtin cd "$@"; }',
-				'pushd () { builtin pushd "$@"; }',
-				'popd () { builtin popd "$@"; }',
+				'function cd () { builtin cd "$@"; }',
+				'function pushd () { builtin pushd "$@"; }',
+				'function popd () { builtin popd "$@"; }',
 			],
 		});
 	}


### PR DESCRIPTION
After enabling NVS AUTO ON (and putting the relative line in .zshrc) I get this message:

``
/home/seba/.nvs/nvs_tmp_1122510616.sh:1: defining function based on alias `cd'
/home/seba/.nvs/nvs_tmp_1122510616.sh:1: parse error near `()'
``

This happens on ZSH v5.7.1 on Archlinux (WSL). I did not test in any other systems.

looks like theway the functions are defined are considered error prone by the zsh development team
putting `function` before those commands fixed the behaviour.