### PR TITLE
feat: add .nmvrc check and arg-less `nvs add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $ nvs which myalias/32
 [An alias may also refer to a local directory](doc/ALIAS.md#aliasing-directories), enabling NVS to switch to a local private build of node.
 
 ## Automatic switching per directory
-In either Bash or PowerShell, NVS can automatically switch the node version in the current shell as you change directories. This function is disabled by default; to enable it run `nvs auto on`. Afterward, whenever you `cd` or `pushd` under a directory containing a `.node-version` or an [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc)<sup>[1](#nvmrcNote)</sup> file then NVS will automatically switch the node version accordingly, downloading a new version if necessary. When you `cd` out to a directory with no `.node-version` or `.nvmrc` file anywhere above it, then the default (linked) version is restored, if any.
+In either Bash or PowerShell, NVS can automatically switch the node version in the current shell as you change directories. This function is disabled by default; to enable it run `nvs auto on`. Afterward, whenever you `cd` or `pushd` under a directory containing a `.node-version` or an [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) file then NVS will automatically switch the node version accordingly, downloading a new version if necessary. When you `cd` out to a directory with no `.node-version` or `.nvmrc` file anywhere above it, then the default (linked) version is restored, if any.
 ```
 ~$ nvs link 6.9.1
 ~/.nvs/default -> ~/.nvs/node/6.9.1/x64
@@ -153,10 +153,8 @@ PATH += ~/.nvs/default/bin
 ```
 *This feature is not available in Windows Command Prompt. Use PowerShell instead.*
 
-<a name="nvmrcNote"><sup>1</sup></a> *`.nvmrc` parsing is best effort at the moment. Please log an issue if `nvs` fails on a valid `.nvmrc` file.*
-
-## Manual switching use `.node-version`
-If your shell isn't compatible with automatic switching or you'd prefer to switch manual, but still take advantage of any `.node-version` or `.nvmrc` files, you run `use` with the version `auto` or just run `nvs auto`.
+## Manual switching using `.node-version`
+If your shell isn't compatible with automatic switching or you'd prefer to switch manually but still take advantage of any `.node-version` or `.nvmrc` files, you can run `nvs use` with the version `auto` or just run `nvs auto`.
 
 ```
 $ nvs use auto

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Command | Description
 `nvs install`                    | Initialize your profile for using NVS
 `nvs uninstall`                  | Remove NVS from profile and environment
 `nvs --version`                  | Display the NVS tool version
-`nvs add <version>`              | Download and extract a node version
+`nvs add [version]`              | Download and extract a node version
 `nvs rm <version>`               | Remove a node version
 `nvs migrate <fromver> [tover]`  | Migrate global modules
 `nvs upgrade [fromver]`          | Upgrade to latest patch of major version
@@ -137,7 +137,7 @@ $ nvs which myalias/32
 [An alias may also refer to a local directory](doc/ALIAS.md#aliasing-directories), enabling NVS to switch to a local private build of node.
 
 ## Automatic switching per directory
-In either Bash or PowerShell, NVS can automatically switch the node version in the current shell as you change directories. This function is disabled by default; to enable it run `nvs auto on`. Afterward, whenever you `cd` or `pushd` under a directory containing a `.node-version` file then NVS will automatically switch the node version accordingly, downloading a new version if necessary. When you `cd` out to a directory with no `.node-version` file anywhere above it, then the default (linked) version is restored, if any.
+In either Bash or PowerShell, NVS can automatically switch the node version in the current shell as you change directories. This function is disabled by default; to enable it run `nvs auto on`. Afterward, whenever you `cd` or `pushd` under a directory containing a `.node-version` or an [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc)<sup>[1](#nvmrcNote)</sup> file then NVS will automatically switch the node version accordingly, downloading a new version if necessary. When you `cd` out to a directory with no `.node-version` or `.nvmrc` file anywhere above it, then the default (linked) version is restored, if any.
 ```
 ~$ nvs link 6.9.1
 ~/.nvs/default -> ~/.nvs/node/6.9.1/x64
@@ -152,6 +152,21 @@ PATH -= ~/.nvs/node/4.6.1/x64/bin
 PATH += ~/.nvs/default/bin
 ```
 *This feature is not available in Windows Command Prompt. Use PowerShell instead.*
+
+<a name="nvmrcNote"><sup>1</sup></a> *`.nvmrc` parsing is best effort at the moment. Please log an issue if `nvs` fails on a valid `.nvmrc` file.*
+
+## Manual switching use `.node-version`
+If your shell isn't compatible with automatic switching or you'd prefer to switch manual, but still take advantage of any `.node-version` or `.nvmrc` files, you run `use` with the version `auto` or just run `nvs auto`.
+
+```
+$ nvs use auto
+```
+
+is equivalent to
+
+```
+$ nvs auto
+```
 
 # How it works
 

--- a/lib/auto.js
+++ b/lib/auto.js
@@ -15,9 +15,9 @@ let nvsList = require('./list');  // Non-const enables test mocking
 let nvsLink = null;  // Lazy load
 
 /**
- * Searches for the nearest `.node-version` file in the current directory or parent directories.
+ * Searches for the nearest `.node-version` or `.nvmrc` file in the current directory or parent directories.
  * If found, the version specified in the file is then added (if necessary) and returned. If no
- * `.node-version` file is found then 'default' is returned.
+ * `.node-version` or `.nvmrc` file is found then 'default' is returned.
  */
 function findAutoVersionAsync(cwd) {
 	let version = null;
@@ -75,9 +75,9 @@ function findAutoVersionAsync(cwd) {
 }
 
 /**
- * Searches for the nearest `.node-version` file in the current directory or parent directories.
+ * Searches for the nearest `.node-version` or `.nvmrc` file in the current directory or parent directories.
  * If found, the version specified in the file is then added (if necessary) and used. If no
- * `.node-version` file is found, then the default (linked) version, if any, is used.
+ * `.node-version` or `.nvmrc` file is found, then the default (linked) version, if any, is used.
  */
 function autoSwitchAsync(cwd) {
 	if (process.env['NVS_EXECUTE']) {

--- a/lib/auto.js
+++ b/lib/auto.js
@@ -36,7 +36,9 @@ function findAutoVersionAsync(cwd) {
 			versionFile = path.join(dir, '.nvmrc');
 			try {
 				versionString = fs.readFileSync(versionFile, 'utf8').trim();
-			} catch (_) { }
+			} catch (e) {
+				Error.throwIfNot(Error.ENOENT, e, 'Failed to read file: ' + versionFile);
+			}
 		}
 
 		if (versionString) {

--- a/lib/auto.js
+++ b/lib/auto.js
@@ -30,6 +30,15 @@ function findAutoVersionAsync(cwd) {
 		} catch (e) {
 			Error.throwIfNot(Error.ENOENT, e, 'Failed to read file: ' + versionFile);
 		}
+
+		// If we don't have a version string, try checking for an .nvmrc file
+		if (!versionString && !settings.disableNvmrc) {
+			versionFile = path.join(dir, '.nvmrc');
+			try {
+				versionString = fs.readFileSync(versionFile, 'utf8').trim();
+			} catch (_) { }
+		}
+
 		if (versionString) {
 			try {
 				version = NodeVersion.parse(versionString);

--- a/lib/main.js
+++ b/lib/main.js
@@ -108,6 +108,9 @@ function doCommand(args) {
 
 		case 'add':
 			if (help) return help('add');
+			if (!args[1]) {
+				return require('./auto').findAutoVersionAsync();
+			}
 			version = parseVersion(args[1]);
 			return require('./addRemove').addAsync(version);
 

--- a/test/modules/autoTests.js
+++ b/test/modules/autoTests.js
@@ -84,6 +84,15 @@ test.serial('Auto switch based on current dir', t => {
 	});
 });
 
+test.serial('Auto switch based on current dir using nvmrc', t => {
+	mockFs.mockFile('/testA/testB/.nvmrc', '1.2.3');
+	return nvsAuto.autoSwitchAsync('/testA/testB').then(() => {
+		t.is(mockNvsUse.usedVersions.length, 1);
+		t.is(mockNvsUse.usedVersions[0].semanticVersion, '1.2.3');
+		t.deepEqual(mockNvsAddRemove.addedVersions, []);
+	});
+});
+
 test.serial('Auto switch based on parent dir', t => {
 	mockFs.mockFile('/testA/.node-version', '1.2.3');
 	return nvsAuto.autoSwitchAsync('/testA/testB').then(() => {
@@ -95,6 +104,16 @@ test.serial('Auto switch based on parent dir', t => {
 
 test.serial('Auto download and switch based on parent dir', t => {
 	mockFs.mockFile('/testA/.node-version', '2.3.4');
+	return nvsAuto.autoSwitchAsync('/testA/testB').then(() => {
+		t.is(mockNvsAddRemove.addedVersions.length, 1);
+		t.is(mockNvsAddRemove.addedVersions[0].semanticVersion, '2.3.4');
+		t.is(mockNvsUse.usedVersions.length, 1);
+		t.is(mockNvsUse.usedVersions[0].semanticVersion, '2.3.4');
+	});
+});
+
+test.serial('Auto download and switch based on parent dir using nvmrc', t => {
+	mockFs.mockFile('/testA/.nvmrc', '2.3.4');
 	return nvsAuto.autoSwitchAsync('/testA/testB').then(() => {
 		t.is(mockNvsAddRemove.addedVersions.length, 1);
 		t.is(mockNvsAddRemove.addedVersions[0].semanticVersion, '2.3.4');


### PR DESCRIPTION
It looks like you already did a ton of good work in `NodeVersion` to ensure `nvm` compatibility, so it was just a matter of checking for the presence of an `.nvmrc` and attempting to use that version.

Let me know if you think this is good and I'll add test/docs.

Closes #113;