### PR TITLE
Add .nvmrc check to `nvs auto on`

### DIFF
--- a/nvs.ps1
+++ b/nvs.ps1
@@ -72,7 +72,7 @@ elseif ($args -eq "prompt") {
 
 	# Find the nearest .node-version file in current or parent directories
 	for ($parentDir = $pwd.Path; $parentDir; $parentDir = Split-Path $parentDir) {
-		if (Test-Path (Join-Path $parentDir ".node-version") -PathType Leaf) { break }
+		if ((Test-Path (Join-Path $parentDir ".node-version") -PathType Leaf) -or (Test-Path (Join-Path $parentDir ".nvmrc") -PathType Leaf)) { break }
 	}
 
 	# If it's still the same as the last auto-switched directory, then there's nothing to do.

--- a/nvs.sh
+++ b/nvs.sh
@@ -102,7 +102,7 @@ nvs() {
 		"cd")
 			# Find the nearest .node-version file in current or parent directories
 			local DIR=$PWD
-			while [ "$DIR" != "" -a ! -e "$DIR/.node-version" ]; do
+			while [ "$DIR" != "" -a ! \( -e "$DIR/.node-version" -o -e "$DIR/.nvmrc" \) ]; do
 				if [ "$DIR" = "/" ]; then
 					DIR=
 				else


### PR DESCRIPTION
Hi! I've been playing around with nvs and I'm liking it a lot. I work on some projects that use `.nvmrc`s, so I was happy to see support for `.nvmrc` added in #138 

However, when I went to enable auto-change with `cd` using `nvs auto on`, I found that nvs wasn't switching with my `.nvmrc` projects. This PR follows up on the work in 138 to add an `.nvmrc` check to the auto `cd` logic.

Notes:
- I'm not much of a PS person, so please let me know if there was a better way to do that check than brute-forcing it with a copy-paste
- I'm happy to add tests for this behavior, but I couldn't really find any tests for `nvs auto on` behavior
- Are `bash` and `ps` the only places where this auto-cd logic lives?