### PR TITLE
aarch64 treated as arm64

### DIFF
--- a/nvs.sh
+++ b/nvs.sh
@@ -59,7 +59,7 @@ nvs() {
 		fi
 
 		# Download a node binary to use to bootstrap the NVS script.
-		local NODE_ARCH="$(uname -m | sed 's/x86_64/x64/' | sed 's/i686/x86/')"
+		local NODE_ARCH="$(uname -m | sed 's/x86_64/x64/' | sed 's/i686/x86/' | sed 's/aarch64/arm64/' )"
 		local NODE_FULLNAME="node-v${NODE_VERSION}-${NVS_OS}-${NODE_ARCH}"
 		local NODE_URI="${NODE_BASE_URI}v${NODE_VERSION}/${NODE_FULLNAME}${NODE_ARCHIVE_EXT}"
 		local NODE_ARCHIVE="${NVS_HOME}/cache/${NODE_FULLNAME}${NODE_ARCHIVE_EXT}"


### PR DESCRIPTION
As explained on issue #141, aarch64 should be treated as arm64.

This PR simply replaces aarch64 to arm64.