### PR TITLE
update default bootstrap to Node.js 12.18.2 (LTS)

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -5,5 +5,5 @@
 		"default": "node",
 		"node": "https://nodejs.org/dist/"
 	},
-	"bootstrap": "node/10.12.0"
+	"bootstrap": "node/12.18.2"
 }


### PR DESCRIPTION
I have tested this update on macOS Catalina, Windows cmder (desktop), and Ubuntu (cloud), really hope we can get this merged with the security updates. Thanks!