### PR TITLE
fix: make sure 'rm' does not ask the question after every 'nvs use'

### DIFF
--- a/nvs.sh
+++ b/nvs.sh
@@ -157,7 +157,7 @@ nvs() {
 	# This allows the invocation to potentially modify the caller's environment (e.g. PATH)
 	if [ -f "${NVS_POSTSCRIPT}" ]; then
 		. "${NVS_POSTSCRIPT}"
-		rm "${NVS_POSTSCRIPT}"
+		rm -f "${NVS_POSTSCRIPT}"
 		unset NVS_POSTSCRIPT
 	fi
 

--- a/nvs.sh
+++ b/nvs.sh
@@ -157,7 +157,7 @@ nvs() {
 	# This allows the invocation to potentially modify the caller's environment (e.g. PATH)
 	if [ -f "${NVS_POSTSCRIPT}" ]; then
 		. "${NVS_POSTSCRIPT}"
-		rm -f "${NVS_POSTSCRIPT}"
+		command rm "${NVS_POSTSCRIPT}"
 		unset NVS_POSTSCRIPT
 	fi
 


### PR DESCRIPTION
Previously, running 'nvs use' would result in halting the prompt with the following question:

```
remove /Users/my_user/.nvs/nvs_tmp_2036371059.sh? 
```

One had to type 'y' and return every time `nvs use` was run.

This fixes the issue by removing the file without asking the user about it.