### PR TITLE
fix: update object for vscode launch.json configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ When invoked with no parameters, `nvs` displays an interactive menu for switchin
 *NVS uses [**console-menu**](https://github.com/jasongin/console-menu), a module originally written for this project then published separately.*
 
 ## VS Code support
-Visual Studio Code can use NVS to select a node version to use when launching or debugging. In `launch.json`, add a `"runtimeArgs"` attribute with an NVS version string and a `"runtimeExecutable"` attribute that refers to `nvs.cmd` (Windows) or `nvs` (Mac, Linux). (You may need to specify an absolute path such as `"${env:HOME}/.nvs/nvs"` if NVS is not in VS Code's PATH.)
+Visual Studio Code can use NVS to select a node version to use when launching or debugging. In `launch.json` (in the folder `.vscode` located on the project's root folder), add a `"runtimeArgs"` attribute with an NVS version string and a `"runtimeExecutable"` attribute that refers to `nvs.cmd` (Windows) or `nvs` (Mac, Linux). (You may need to specify an absolute path such as `"${env:HOME}/.nvs/nvs"` if NVS is not in VS Code's PATH.)
 
 Example: Configure `launch.json` so VS Code uses NVS to launch node version 6.10:
 ```json
@@ -102,6 +102,7 @@ Example: Configure `launch.json` so VS Code uses NVS to launch node version 6.10
       "osx": { "runtimeExecutable": "nvs" },
       "linux": { "runtimeExecutable": "nvs" }
     },
+  ]
 ```
 
 Or, remove the version string from `"runtimeArgs"` to get the version from a `.node-version` file in the project directory. For more details, see the [NVS VS Code documentation](doc/VSCODE.md) or run `nvs help vscode`.

--- a/doc/VSCODE.md
+++ b/doc/VSCODE.md
@@ -1,6 +1,6 @@
 # VS Code Support - Node Version Switcher
 
-Visual Studio Code can use NVS to select a node version to use when launching or debugging. In `launch.json`, add a `"runtimeArgs"` attribute with a version string recognizable by NVS, and a `"runtimeExecutable"` attribute that refers to `nvs.cmd` (Windows) or `nvs` (Mac, Linux).
+Visual Studio Code can use NVS to select a node version to use when launching or debugging. In `launch.json` (in the folder `.vscode` located on the project's root folder), add a `"runtimeArgs"` attribute with a version string recognizable by NVS, and a `"runtimeExecutable"` attribute that refers to `nvs.cmd` (Windows) or `nvs` (Mac, Linux).
 
 For multi-platform development, configuration can be customized for each platform. You may need to specify an absolute path such as `"${env:HOME}/.nvs/nvs"` if NVS is not in VS Code's PATH.
 
@@ -18,6 +18,7 @@ Example: Configure `launch.json` so VS Code uses NVS to launch node version 6.10
       "osx": { "runtimeExecutable": "nvs" },
       "linux": { "runtimeExecutable": "nvs" }
     },
+  ]
 ```
 
 The NVS version string value in `"runtimeArgs"` consists of a complete or partial semantic version number or version label ("lts", "latest", "Argon", etc.), optionally preceded by a remote name, optionally followed by a processor architecture or bitness ("x86", "x64", "32", "64"), separated by slashes. When a partial version matches multiple available versions, the latest version is automatically selected. Examples: "node/lts", "4.6.0", "6/x86", "node/6.7/x64". An NVS alias may also be used in place of a version string.


### PR DESCRIPTION
Add missing closing bracket for the "configurations" array on the VS Code launch.json file.
Indicate the localization of the file launch.json to clarify any possible doubts.