### PR TITLE
Git Bash install support

### DIFF
--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -52,20 +52,17 @@ git clone https://github.com/jasongin/nvs "$env:NVS_HOME"
 After installation, running just `nvs` from the current shell or any new Command Prompt or PowerShell then invokes either the `nvs.cmd` or `nvs.ps1` script accordingly.
 
 ### Git Bash on Windows
-NVS can work in Git Bash on Windows (the bash tools installed by [Git](https://git-scm.com/) for Windows), though it requires some manual configuration:
+NVS can work in Git Bash on Windows (the bash tools installed by [Git](https://git-scm.com/) for Windows).
 
-1. Install NVS using the either the Windows MSI, Command Prompt, or PowerShell instructions above.
+1. Install NVS using Git Bash (see instructions: [Mac, Linux](#mac-linux) ).
 
-2. Ensure there is a `.bash_profile` file in your home (`%HOMEDRIVE%%HOMEPATH%`) directory that calls `.bashrc`. Create the file if it doesn't exist. It should include at least the following line:
+2. Ensure there is a `.bash_profile` file in your home (`$HOME`) directory that calls `.bashrc`. Create the file if it doesn't 
+	exist. It should include at least the following line:
 ```sh
 if [ -f ~/.bashrc ]; then . ~/.bashrc; fi
 ```
 
-3. Ensure there is a `.bashrc` file in the same directory. Create the file if it doesn't exist, and add the following lines. (If necessary, replace `$LOCALAPPDATA` with `$ProgramData` or other custom installation path.)
-```sh
-export NVS_HOME=$LOCALAPPDATA/nvs
-. $NVS_HOME/nvs.sh
-```
+`.bashrc` file is created by NVS if it does not exists.
 
 ### Ubuntu Bash on Windows 10
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -12,7 +12,8 @@ let nvsLink = require('./link');
 let nvsPostScript = require('./postScript');
 let nvsAuto = require('./auto');
 
-const isWindows = process.platform === 'win32';
+const isMingwBash = nvsUse.isMingwBash;
+const isWindows = nvsUse.isWindows;
 
 function install() {
 	let result = [];
@@ -85,6 +86,12 @@ function uninstall() {
 }
 
 function getShellProfile() {
+	const profileFile = process.env['NVS_SHELL_PROFILE'];
+
+	if (profileFile) {
+		return profileFile;
+	}
+
 	let fileExists = f => {
 		try {
 			fs.accessSync(f);
@@ -121,6 +128,17 @@ function getShellProfile() {
 		if (fileExists(path.join(userHome, '.profile'))) {
 			return path.join(userHome, '.profile');
 		}
+
+		if (isMingwBash) {
+			if (fileExists(path.join(userHome, '.bashrc'))) {
+				return path.join(userHome, '.bashrc');
+			}
+			if (fileExists(path.join(userHome, '.bash_profile'))) {
+				return path.join(userHome, '.bash_profile');
+			}
+			// force create .bashrc for MINGW64
+			return path.join(userHome, '.bashrc');
+		}
 	}
 
 	return null;
@@ -128,14 +146,24 @@ function getShellProfile() {
 
 function installToShellProfile(profileFile) {
 	let homePath = nvsUse.homePath(settings.home).replace('~', '$HOME');
-	if (homePath.endsWith('/')) {
+	if (homePath.endsWith('/') || homePath.endsWith('\\')) {
 		homePath = homePath.substr(0, homePath.length - 1);
 	}
 
-	let installLines = [
-		'export NVS_HOME="' + homePath + '"',
-		'[ -s "$NVS_HOME/nvs.sh" ] && . "$NVS_HOME/nvs.sh"',
-	];
+	const installLines = isMingwBash
+		? [
+			'function setupNvs {',
+			'	export NVS_HOME="' + homePath + '";',
+			'	[ -s "$NVS_HOME/nvs.sh" ] && source "$NVS_HOME/nvs.sh" >> /dev/null;',
+			'	return 0;',
+			'}',
+			'setupNvs',
+		]
+		// normal POSIX shell
+		: [
+			'export NVS_HOME="' + homePath + '"',
+			'[ -s "$NVS_HOME/nvs.sh" ] && . "$NVS_HOME/nvs.sh"',
+		];
 
 	if (!profileFile) {
 		return [
@@ -145,7 +173,7 @@ function installToShellProfile(profileFile) {
 		].concat(installLines).concat(['']);
 	}
 
-	let profileContents = fs.readFileSync(profileFile, 'utf8');
+	let profileContents = fs.existsSync(profileFile) ? fs.readFileSync(profileFile, 'utf8') : '';
 	if (/\/nvs.sh/.test(profileContents)) {
 		return [
 			'NVS invocation detected already in profile file: ' +

--- a/lib/use.js
+++ b/lib/use.js
@@ -13,7 +13,8 @@ const NodeVersion = require('./version');
 let nvsList = null;  // Lazy load
 let nvsLink = null;  // Lazy load
 
-const isWindows = process.platform === 'win32';
+const isMingwBash = process.env['MSYSTEM'] === 'MINGW64';
+const isWindows = !isMingwBash && process.platform === 'win32';
 const isMac = process.platform === 'darwin';
 
 const linkName = 'default';
@@ -37,7 +38,7 @@ function getCurrentVersion() {
 		}
 
 		if (pathEntry.toLowerCase().startsWith(settings.home.toLowerCase())) {
-			if (!isWindows) {
+			if (!isWindows && !isMingwBash) {
 				if (pathEntry.endsWith(path.sep + 'bin')) {
 					pathEntry = pathEntry.substr(0, pathEntry.length - 4);
 				} else if (pathEntry !== getLinkPath()) {
@@ -127,7 +128,7 @@ function use(version, skipUpdateShellEnv) {
 
 		let previousVersion = null;
 		if (pathEntry.toLowerCase().startsWith(settings.home.toLowerCase())) {
-			if (!isWindows) {
+			if (!isWindows && !isMingwBash) {
 				if (pathEntry.endsWith(path.sep + 'bin')) {
 					pathEntry = pathEntry.substr(0, pathEntry.length - 4);
 				} else if (pathEntry !== getLinkPath()) {
@@ -165,7 +166,7 @@ function use(version, skipUpdateShellEnv) {
 				version = null;
 			} else {
 				pathEntries.splice(i--, 1);
-				if (!isWindows &&
+				if (!isWindows && !isMingwBash &&
 					!(previousVersion instanceof NodeVersion && previousVersion.path)
 				) {
 					pathEntry = path.join(pathEntry, 'bin');
@@ -183,7 +184,7 @@ function use(version, skipUpdateShellEnv) {
 		let version = nvsLink.getLinkedVersion();
 		if (version) {
 			versionBinDir = getLinkPath();
-			if (!isWindows && !version.path) {
+			if (!isWindows && !isMingwBash && !version.path) {
 				versionBinDir = path.join(versionBinDir, 'bin');
 			}
 		} else {
@@ -347,7 +348,7 @@ function getVersionDir(version) {
  */
 function getVersionBinDir(version) {
 	let versionDir = getVersionDir(version);
-	if (!isWindows && !version.path) {
+	if (!isWindows && !isMingwBash && !version.path) {
 		versionDir = path.join(versionDir, 'bin');
 	}
 	return versionDir;
@@ -367,7 +368,7 @@ function getVersionBinary(version) {
 
 	// Resolve the version to a path and check if the binary exists.
 	let binaryName = NodeVersion.getBinaryNameFromVersion(version.semanticVersion);
-	let nodeBinPath = path.join(getVersionBinDir(version), isWindows ? binaryName + '.exe' : binaryName);
+	let nodeBinPath = path.join(getVersionBinDir(version), isWindows || isMingwBash ? binaryName + '.exe' : binaryName);
 	try {
 		fs.accessSync(nodeBinPath, fs.constants.X_OK);
 		return nodeBinPath;
@@ -406,13 +407,14 @@ function getLinkPath() {
 }
 
 function getSystemLinkPath() {
-	if (isWindows) {
+	if (isWindows || isMingwBash) {
 		return path.join(process.env['ProgramFiles'], 'nodejs');
 	}
 }
 
 module.exports = {
 	isWindows,
+	isMingwBash,
 	isMac,
 	use,
 	run,

--- a/test/cli/gitBashTests.js
+++ b/test/cli/gitBashTests.js
@@ -7,8 +7,9 @@ let test = require('ava').default;
 const nvsRootDir = path.resolve(__dirname, '..', '..');
 const testParentDir = path.resolve(__dirname, '..', 'temp');
 const testDir = path.join(testParentDir, 'git-bash');
+const shellProfileFile = path.join(testParentDir, '.shell_profile');
 
-const testNodeVersion = '8.5.0';
+const testNodeVersion = '10.24.1';
 const testNpmVersion = '6.4.1';
 
 test.before(t => {
@@ -23,28 +24,14 @@ if (process.platform !== 'win32') {
 	test = test.skip;
 }
 
-test('Git Bash CLI', t => {
-	const commands = [
-		'echo $NVS_HOME',
-		'. ./nvs.sh',
-		'nvs lsr 8',
-		'nvs add ' + testNodeVersion,
-		'nvs link ' + testNodeVersion,
-		'nvs use',
-		'echo $PATH',
-		'node -v',
-		// `npm install -g npm` doesn't work in Git bash, because the `npm` script file
-		// (being executed) is locked while the npm install process tries to update it.
-		// The workaround is to run the command via cmd.exe outside of bash.
-		`cmd "/C npm install -g npm@${testNpmVersion}"`,
-		'npm -v',
-		'nvs unlink',
-		'rm -rf $NVS_HOME',
-	];
+function runInGitBash(commands, nvsHome) {
 	for (let i = commands.length - 1; i >= 0; i--) {
 		// Print each command before executing it.
 		commands.splice(i, 0, 'echo \\> ' + commands[i].replace('$', '\\$'));
 	}
+
+	// source rc file
+	commands.unshift('[ -s "' + shellProfileFile + '" ] && source "' + shellProfileFile + '"');
 
 	const gitBashExe = path.join(process.env['ProgramFiles'], 'Git', 'bin', 'bash.exe');
 	const result = childProcess.spawnSync(
@@ -52,14 +39,63 @@ test('Git Bash CLI', t => {
 		[ '-c', commands.join('; ') ],
 		{
 			env: {
-				'NVS_HOME': testDir,
+				'NVS_HOME': nvsHome,
 				'NVS_LINK_TO_SYSTEM': '0',
 				'NVS_DEBUG': '1',
 				'ProgramFiles': process.env['ProgramFiles'],
+				'NVS_SHELL_PROFILE': shellProfileFile,
 			},
 			cwd: nvsRootDir,
 		});
+	return result;
+}
+
+test('Git Bash CLI', t => {
+	const result = runInGitBash([
+		'echo $NVS_HOME',
+		'. ./nvs.sh',
+		'nvs lsr 10',
+		'nvs add ' + testNodeVersion,
+		'nvs link ' + testNodeVersion,
+		'nvs use',
+		'node -v',
+		// `npm install -g npm` doesn't work in Git bash, because the `npm` script file
+		// (being executed) is locked while the npm install process tries to update it.
+		// The workaround is to run the command via cmd.exe outside of bash.
+		`cmd "/C npm install -g npm@${testNpmVersion}"`,
+		'echo $PATH',
+		'npm -v',
+		'nvs unlink',
+	], testDir);
+
 	const output = result.stdout.toString().trim().replace(/\r\n/g, '\n');
 	t.regex(output, new RegExp('\n> node -v *\nv' + testNodeVersion + ' *\n', 'm'));
 	t.regex(output, new RegExp('\n> npm -v *\n' + testNpmVersion + ' *\n', 'm'));
+});
+
+test('Git Bash CLI - nvs install', t => {
+	const result = runInGitBash([
+		'. ./nvs.sh install',
+		'nvs add ' + testNodeVersion,
+		'nvs link ' + testNodeVersion,
+		'nvs use',
+		'node -v',
+	], nvsRootDir);
+
+	const output = result.stdout.toString().trim().replace(/\r\n/g, '\n');
+	t.regex(output, new RegExp('\n> node -v *\nv' + testNodeVersion + ' *', 'm'));
+
+	const testNodeVersion14 = '14.15.4';
+
+	const resultAfterInstall = runInGitBash([
+		'nvs add ' + testNodeVersion14,
+		'nvs link ' + testNodeVersion14,
+		'nvs use ' + testNodeVersion14,
+		'echo $PATH',
+		'node -v',
+		'nvs unlink',
+	], nvsRootDir);
+
+	const outputInstall = resultAfterInstall.stdout.toString().trim().replace(/\r\n/g, '\n');
+	t.regex(outputInstall, new RegExp('\n> node -v *\nv' + testNodeVersion14 + ' *\n', 'm'));
 });


### PR DESCRIPTION
Git Bash requires a different form of initialisation.
Details:
 - this bash has mixed POSIX - Windows path handling
 - the RC script exits and fails because of sourcing if it's not redirected to /dev/null