### PR TITLE
Natively support Apple Silicon to bootstrap the NVS script

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -5,5 +5,5 @@
 		"default": "node",
 		"node": "https://nodejs.org/dist/"
 	},
-	"bootstrap": "node/16.13.0"
+	"bootstrap": "node/16.14.2"
 }

--- a/defaults.json
+++ b/defaults.json
@@ -5,5 +5,5 @@
 		"default": "node",
 		"node": "https://nodejs.org/dist/"
 	},
-	"bootstrap": "node/12.22.2"
+	"bootstrap": "node/16.13.0"
 }

--- a/nvs.sh
+++ b/nvs.sh
@@ -65,10 +65,7 @@ nvs() {
 		if [ "${NVS_OS}" = "aix" ]; then
 			NODE_ARCH="ppc64"
 		fi
-		# Automatically select x64 instead of arm64 when on macOS
-		if [ "${NVS_OS}" = "darwin" ] && [ "${NODE_ARCH}" = "arm64" ]; then
-			NODE_ARCH="x64"
-		fi
+
 		local NODE_FULLNAME="node-v${NODE_VERSION}-${NVS_OS}-${NODE_ARCH}"
 		local NODE_URI="${NODE_BASE_URI}v${NODE_VERSION}/${NODE_FULLNAME}${NODE_ARCHIVE_EXT}"
 		local NODE_ARCHIVE="${NVS_HOME}/cache/${NODE_FULLNAME}${NODE_ARCHIVE_EXT}"


### PR DESCRIPTION
When install NVS, I hit a similar issue(#182 ) on my new macbook pro 14in (running macOS Monterey) :
      `ethan@EthandeMacBook-Pro cache % . "$NVS_HOME/nvs.sh" install`
      `nvs:119: bad CPU type in executable: /Users/ethan/.nvs/cache/node`
Nvs currently defaults to downloading node binaries compiled for x64 on Apple Silicon.  However , node V16  provides [prebuilt binaries](https://nodejs.org/dist/v16.13.0/)(darwin-arm64) for Apple Silicon, and 16.x release line now moves into "Active LTS".  Using Node V16.13.0 to bootstrap the NVS  ,  it could fix this error and works fine on my M1 mac.
➜  ~ nvs ls
>#node/16.13.0/arm64 (Gallium)
