### PR TITLE
Correctly wait on promisified cmdShim

### DIFF
--- a/lib/addRemove.js
+++ b/lib/addRemove.js
@@ -3,6 +3,7 @@
 
 let fs = require('fs');  // Non-const enables test mocking
 const path = require('path');
+const util = require('util');
 
 const settings = require('./settings').settings;
 const Error = require('./error');
@@ -341,10 +342,13 @@ async function fixNpmCmdShimsAsync(targetDir) {
 
 			// Found an npm shim. Call the cmd-shim module to fix it.
 			await new Promise((resolve, reject) => {
-				cmdShim(jsCliPath, shimPath, (e) => {
+				const p = cmdShim(jsCliPath, shimPath, (e) => {
 					if (e) reject(e);
 					else resolve();
 				});
+				if (util.types.isPromise(p)) {
+					p.then(resolve, reject);
+				}
 			});
 		}
 	} catch (e) {


### PR DESCRIPTION
The internal cmd-shim module of npm has been promisified in
https://github.com/npm/cmd-shim/commit/48fd8118057a19830e154231991a9acdb1a5610d
(Version 4+ and above I think)

As such the callback was never invoked, and the promise never resolved,
leading to code after it to not run, such as the code to write the
version label to an `.nvs` file. This causes the issue in #218.

Fixes #218
