### PR TITLE
Add linking to specified location in homebrew install script

### DIFF
--- a/homebrew/install.sh
+++ b/homebrew/install.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+LINK_DIR=$1
 NVS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 # Set environment variables
@@ -8,3 +9,6 @@ export NVS_HOME=~/.nvs
 
 # Run install script
 \. $NVS_DIR/nvs.sh install
+
+# Link to a specified location to avoid changing shell profile while upgrading
+ln -Ffs $NVS_DIR $LINK_DIR


### PR DESCRIPTION
Patch for Homebrew upgrades:

Homebrew upgrades run the same "install script" but save to an `nvs-${version}` folder, and this will break users' existing shell profiles. Thus, we want the installed location to be a universal location. A soft link to a location specified in the Homebrew cask is perfect to mitigate this issue and ensure that upgrades work well. 