### PR TITLE
Fix: throw ERR_INVALID_PROTOCOL when access remote https url through http proxy

### DIFF
--- a/deps/node_modules/agent-base/dist/src/index.js
+++ b/deps/node_modules/agent-base/dist/src/index.js
@@ -13,7 +13,7 @@ function isSecureEndpoint() {
     const { stack } = new Error();
     if (typeof stack !== 'string')
         return false;
-    return stack.split('\n').some(l => l.indexOf('(https.js:') !== -1);
+    return stack.split('\n').some(l => l.indexOf('(https.js:') !== -1 || l.indexOf('(node:https:') !== -1);
 }
 function createAgent(callback, opts) {
     return new createAgent.Agent(callback, opts);


### PR DESCRIPTION
utilize stack trace to solve this problem. Refer to https://github.com/TooTallNate/node-agent-base/pull/47

Fixes https://github.com/jasongin/nvs/issues/239.