### PR TITLE
fix: do not use dynamic module in post-script for PowerShell

### DIFF
--- a/lib/auto.js
+++ b/lib/auto.js
@@ -112,15 +112,19 @@ function enableAutoSwitch(enable) {
 		require('./postScript').generate(null, {
 			'.PS1': [
 				// Patch the function that is invoked every time PowerShell shows a prompt.
-				// Export the function from the script using a dynamic module; this
-				// does NOT require the script to be sourced.
-				'if (-not $env:NVS_ORIGINAL_PROMPT) { ',
-				'   $env:NVS_ORIGINAL_PROMPT = $(Get-Content function:\\prompt)',
+				// This does NOT require the script to be sourced.
+				'if (-not $global:NVS_ORIGINAL_PROMPT) {',
+				'  $global:NVS_ORIGINAL_PROMPT = $Function:prompt',
 				'}',
-				'New-Module -Script {',
-				'   function prompt { . "' + psScriptFile + '" "prompt" }',
-				'   Export-ModuleMember -Function prompt',
-				'} > $null',
+				'function global:prompt {',
+				'  # We have to do this so a prompt customization tool (like Oh My Posh or Starship) can get',
+				'  # the correct last command execution status and native command return code.',
+				'  $global:NVS_ORIGINAL_LASTEXECUTIONSTATUS = $?',
+				'  $originalExitCode = $global:LASTEXITCODE',
+				'  . "' + psScriptFile + '" "prompt"',
+				'  $global:LASTEXITCODE = $originalExitCode',
+				'  $global:NVS_ORIGINAL_PROMPT.Invoke()',
+				'}',
 			],
 			'.SH': [
 				'function cd () { builtin cd "$@" && nvs cd; }',
@@ -131,11 +135,9 @@ function enableAutoSwitch(enable) {
 	} else {
 		require('./postScript').generate(null, {
 			'.PS1': [
-				'if ($env:NVS_ORIGINAL_PROMPT) { ',
-				'   New-Module -Script {',
-				'      function prompt { Invoke-Expression $env:NVS_ORIGINAL_PROMPT }',
-				'      Export-ModuleMember -Function prompt',
-				'   } > $null',
+				'if ($global:NVS_ORIGINAL_PROMPT) {',
+				'  $Function:prompt = $global:NVS_ORIGINAL_PROMPT',
+				'  Remove-Variable -Name @("NVS_ORIGINAL_PROMPT", "NVS_ORIGINAL_LASTEXECUTIONSTATUS") -Scope global',
 				'}',
 			],
 			'.SH': [

--- a/nvs.ps1
+++ b/nvs.ps1
@@ -85,8 +85,7 @@ if ($args -eq "bootstrap") {
 	exit 0
 }
 elseif ($args -eq "prompt") {
-	# This script was invoked as a PS prompt function that enables auto-switching.
-	Invoke-Expression $env:NVS_ORIGINAL_PROMPT
+	# This script was invoked in a PS prompt function that enables auto-switching.
 
 	# Find the nearest .node-version file in current or parent directories
 	for ($parentDir = $pwd.Path; $parentDir; $parentDir = Split-Path $parentDir) {
@@ -109,7 +108,7 @@ elseif ($args -eq "prompt") {
 	while (($b = $proc.StandardOutput.Read()) -ne -1) {
 		Write-Host -NoNewline ([char]$b)
 	}
-	$proc.WaitForExit
+	$proc.WaitForExit()
 	$exitCode = $proc.ExitCode
 }
 else {


### PR DESCRIPTION
Currently, the dynamic module used in a post-script for PowerShell exports a `prompt` function, which overrides the original. It also uses an environment variable `NVS_ORIGINAL_PROMPT` to store the entire stringified original `prompt` function. However, there is a flaw: if the original `prompt` is defined inside a dynamic module as well, functions defined in that module will become inaccessible for `$env:NVS_ORIGINAL_PROMPT`, which is invoked by the NVS-defined `prompt`. This is caused by some "isolation" features of PowerShell modules. Related code:

https://github.com/jasongin/nvs/blob/bf45ef070e82356ed36a0f4d98f8ec651c8f0d98/lib/auto.js#L120-L123

Related issue: JanDeDobbeleer/oh-my-posh#2568.

Since NVS is not a tool of prompt customization, it should respect the user's custom `prompt` function. As an alternative, we can save the original `prompt` in a global variable when we use `nvs auto on` to enable the auto-switching so that it can be invoked/restored correctly. Also, we have to store the original `$?` in another global variable which is accessible for the initialization script of a prompt customization tool and restore the original `$global:LASTEXITCODE` after the auto-switching done so that the original `prompt` function can get the correct error code.

❤️ Special thanks to @possum-enjoyer for the help and comments in #253.
