### PR TITLE
Refactor HTTP code

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -4,14 +4,10 @@
 const crypto = require('crypto');
 const path = require('path');
 const stream = require('stream');
-const url = require('url');
+const { URL } = require('url');
 const ProgressBar = require('../deps/node_modules/progress/index');
-const { HttpProxyAgent } = require('../deps/node_modules/http-proxy-agent/dist/index');
-const { HttpsProxyAgent } = require('../deps/node_modules/https-proxy-agent/dist/index');
-
 let fs = require('fs');  // Non-const enables test mocking
-let { http, https } = require('../deps/node_modules/follow-redirects/index');  // Non-const enables test mocking
-
+let { httpGet } = require('./http');  // Non-const enables test mocking
 const settings = require('./settings').settings;
 const Error = require('./error');
 
@@ -42,17 +38,8 @@ function downloadFileAsync(filePath, fileUri) {
 				});
 			} else {
 				// Download from the web.
-				const secure = fileUri.startsWith('https:');
-				const httpGet = secure
-					? https.get.bind(https) : http.get.bind(http);
-				const proxy = secure
-					? process.env.https_proxy || process.env.HTTPS_PROXY
-					: process.env.http_proxy || process.env.HTTP_PROXY;
-				const Agent = secure ? HttpsProxyAgent : HttpProxyAgent;
-				/** @type {any} */
-				let opt = url.parse(fileUri);
-				if (proxy) opt.agent = new Agent(proxy);
-				httpGet(opt, (res) => {
+				const url = new URL(fileUri);
+				httpGet(url, {}, (res) => {
 					if (res.statusCode === 200) {
 						let totalBytes = parseInt(res.headers['content-length'], 10);
 						let progressFormat = 'Downloading [:bar] :percent-4 :eta-3s ';

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,0 +1,28 @@
+// @ts-check
+'use strict';
+
+const { http, https } = require('../deps/node_modules/follow-redirects/index');
+const { HttpProxyAgent } = require('../deps/node_modules/http-proxy-agent/dist/index');
+const { HttpsProxyAgent } = require('../deps/node_modules/https-proxy-agent/dist/index');
+
+/**
+ * Sends an HTTP or HTTPS GET request, using proxy settings and following redirects.
+ * @param {import('url').URL} url
+ * @param {import('http').RequestOptions} opt
+ * @param {(res: import('http').IncomingMessage) => void} cb
+ * @returns {import('http').ClientRequest}
+ */
+function httpGet(url, opt, cb) {
+	opt = opt || {};
+	const secure = url.protocol === 'https:';
+	const proxy = secure
+		? process.env.https_proxy || process.env.HTTPS_PROXY
+		: process.env.http_proxy || process.env.HTTP_PROXY;
+	const Agent = secure ? HttpsProxyAgent : HttpProxyAgent;
+	if (proxy) opt.agent = new Agent(proxy);
+	return secure ? https.get(url, opt, cb) : http.get(url, opt, cb);
+}
+
+module.exports = {
+	httpGet,
+};

--- a/lib/list.js
+++ b/lib/list.js
@@ -2,12 +2,9 @@
 'use strict';
 
 const path = require('path');
-const url = require('url');
+const { URL } = require('url');
 let fs = require('fs');   // Non-const enables test mocking
-let { http, https } = require('../deps/node_modules/follow-redirects/index');  // Non-const enables test mocking
-const { HttpProxyAgent } = require('../deps/node_modules/http-proxy-agent/dist/index');
-const { HttpsProxyAgent } = require('../deps/node_modules/https-proxy-agent/dist/index');
-
+let { httpGet } = require('./http');  // Non-const enables test mocking
 const settings = require('./settings').settings;
 const Error = require('./error');
 
@@ -337,18 +334,9 @@ function _getRemoteVersionsAsync(remoteName) {
 function getNodejsRemoteVersionsAsync(remoteName, remoteUri) {
 	let remoteIndexUri = remoteUri + (remoteUri.endsWith('/') ? '' : '/') + 'index.json';
 
-	const secure = remoteIndexUri.startsWith('https:');
-	const httpGet = secure
-		? https.get.bind(https) : http.get.bind(http);
-	const proxy = secure
-		? process.env.https_proxy || process.env.HTTPS_PROXY
-		: process.env.http_proxy || process.env.HTTP_PROXY;
-	const Agent = secure ? HttpsProxyAgent : HttpProxyAgent;
-	/** @type {any} */
-	let opt = url.parse(remoteIndexUri);
-	if (proxy) opt.agent = new Agent(proxy);
+	const url = new URL(remoteIndexUri);
 	return new Promise((resolve, reject) => {
-		httpGet(opt, (res) => {
+		httpGet(url, {}, (res) => {
 			if (res.statusCode === 200) {
 				let responseBody = '';
 				res.on('data', (data) => {
@@ -522,11 +510,8 @@ function getGithubRemoteVersionsAsync(remoteName, remoteUri) {
 			headers['Authorization'] = 'token ' + token;
 		}
 
-		https.get({
-			hostname: 'api.github.com',
-			path: `/repos/${owner}/${repo}/releases`,
-			headers,
-		}, (res) => {
+		const url = new URL(`https://api.github.com/repos/${owner}/${repo}/releases`);
+		httpGet(url, { headers }, res => {
 			let responseBody = '';
 			res.on('data', (data) => {
 				responseBody += data;

--- a/test/mocks/http.js
+++ b/test/mocks/http.js
@@ -12,16 +12,12 @@ const mockHttp = {
 		this.requests = [];
 	},
 
-	get(uri, cb) {
-		if (typeof uri === 'object' && uri.hostname) {
-			uri = (uri.protocol || 'https:') + '//' + uri.hostname + (uri.path || '/');
-		}
-
-		if (this.trace) console.log('GET ' + uri);
+	get(url, opt, cb) {
+		if (this.trace) console.log('GET ' + url);
 
 		let mockRequest = new EventEmitter();
 		let mockResponse = new EventEmitter();
-		let responseContent = this.resourceMap[uri];
+		let responseContent = this.resourceMap[url.toString()];
 		if (responseContent) {
 			mockResponse.statusCode = 200;
 			mockResponse.headers = {

--- a/test/modules/addRemoveTests.js
+++ b/test/modules/addRemoveTests.js
@@ -47,8 +47,7 @@ nvsAddRemove.__set__('nvsLink', nvsLink);
 nvsAddRemove.__set__('nvsDownload', nvsDownload);
 nvsAddRemove.__set__('nvsExtract', nvsExtract);
 nvsAddRemove.__set__('fs', mockFs);
-nvsDownload.__set__('http', mockHttp);
-nvsDownload.__set__('https', mockHttp);
+nvsDownload.__set__('httpGet', mockHttp.get.bind(mockHttp));
 nvsDownload.__set__('fs', mockFs);
 nvsExtract.__set__('childProcess', mockChildProc);
 

--- a/test/modules/listTests.js
+++ b/test/modules/listTests.js
@@ -32,8 +32,7 @@ const getGithubRemoteVersionsAsync = nvsList.getGithubRemoteVersionsAsync;
 const getNetworkRemoteVersionsAsync = nvsList.getNetworkRemoteVersionsAsync;
 
 nvsList.__set__('fs', mockFs);
-nvsList.__set__('http', mockHttp);
-nvsList.__set__('https', mockHttp);
+nvsList.__set__('httpGet', mockHttp.get.bind(mockHttp));
 
 const bin = (process.platform === 'win32' ? '' : 'bin');
 const exe = (process.platform === 'win32' ? 'node.exe' : 'node');


### PR DESCRIPTION
Resolve a few issues with HTTP code by refactoring to a shared `httpGet()` function:
 - Proxy logic was duplicated in 2 places and not applied in a 3rd place.
 - The `url.parse()` API was deprecated.
 - Type info was lost (not checked by `tsc`) due to the way the follow-redirects module was inserted.
