### PR TITLE
Update VSCODE.md for compatibility with non .js files

### DIFF
--- a/doc/VSCODE.md
+++ b/doc/VSCODE.md
@@ -4,7 +4,7 @@ Visual Studio Code can use NVS to select a node version to use when launching or
 
 For multi-platform development, configuration can be customized for each platform. You may need to specify an absolute path such as `"${env:HOME}/.nvs/nvs"` if NVS is not in VS Code's PATH.
 
-Example: Configure `launch.json` so VS Code uses NVS to launch node version 6.10:
+Example: Configure `launch.json` so VS Code uses NVS to launch node version 18.17:
 ```json
   "configurations": [
     {
@@ -13,7 +13,7 @@ Example: Configure `launch.json` so VS Code uses NVS to launch node version 6.10
       "name": "Launch Program",
       "program": "${file}",
       "args": [ ],
-      "runtimeArgs": [ "6.10" ],
+      "runtimeArgs": [ "exec", "18.17", "node" ],
       "windows": { "runtimeExecutable": "nvs.cmd" },
       "osx": { "runtimeExecutable": "nvs" },
       "linux": { "runtimeExecutable": "nvs" }


### PR DESCRIPTION
Added `exec` to `runtimeArgs` in the launch config so it'll work with files like `.mjs`, `.cjs`, etc.
Also updated version numbers to latest node LTS version

Currently on Windows with nvs 1.7.0 without `exec`, launching debug on a non `.js` file will simply exit immediately with no warning.