### PR TITLE
mention .nvmrc files in help text

### DIFF
--- a/doc/AUTO.md
+++ b/doc/AUTO.md
@@ -4,7 +4,7 @@
     nvs auto on
     nvs auto off
 
-When invoked with no parameters, `nvs auto` searches for the nearest `.node-version` file in the current directory or parent directories. If found, the version specified in the file is then downloaded (if necessary) and used. If no `.node-version` file is found, then the default (linked) version, if any, is used.
+When invoked with no parameters, `nvs auto` searches for the nearest `.node-version` or `.nvmrc` file in the current directory or parent directories. If found, the version specified in the file is then downloaded (if necessary) and used. If no `.node-version` or `.nvmrc` file is found, then the default (linked) version, if any, is used.
 
 The `nvs auto on` command enables automatic switching as needed whenever the current shell's working directory changes; `nvs auto off` disables automatic switching in the current shell. (This feature is not supported in Windows Command Prompt.)
 


### PR DESCRIPTION
nvs started supporting use of .nvmrc files for automatic switching per directory in #138. The project's `README.md` was updated to document that behavior, but the help text provided by `nvs help auto` was not. This PR updates the `nvs help auto` text to match what's already documented in  `README.md` 